### PR TITLE
Feedback updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y ca-certificates bash tzdata hwloc libhwloc-dev wget
 
-COPY --from=builder /app/build/eth-jit-exiter/eth-jit-exiter /bin/
+COPY --from=builder /app/build/eth-jit-exiter/eth-jit-exiter /usr/local/bin/
 
 RUN mkdir /var/lib/eth-jit-exiter && chmod 0777 /var/lib/eth-jit-exiter
 
-ENTRYPOINT [ "/bin/eth-jit-exiter" ]
+ENTRYPOINT [ "/usr/local/bin/eth-jit-exiter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ WORKDIR /app
 
 COPY . .
 
-# RUN rm /app/poetry.lock
-
 RUN poetry install
 
 RUN ./build.sh
 
-RUN mv build/eth-jit-exiter/eth-jit-exiter /bin/eth-jit-exiter
+FROM debian:bullseye-slim
+
+COPY --from=builder /app/build/eth-jit-exiter/eth-jit-exiter /bin/
 
 ENTRYPOINT [ "/bin/eth-jit-exiter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN ./build.sh
 
 FROM debian:bullseye-slim
 
+RUN apt-get update && apt-get install -y ca-certificates bash tzdata hwloc libhwloc-dev wget
+
 COPY --from=builder /app/build/eth-jit-exiter/eth-jit-exiter /bin/
 
 ENTRYPOINT [ "/bin/eth-jit-exiter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ RUN apt-get update && apt-get install -y ca-certificates bash tzdata hwloc libhw
 
 COPY --from=builder /app/build/eth-jit-exiter/eth-jit-exiter /bin/
 
+RUN mkdir /var/lib/eth-jit-exiter && chmod 0777 /var/lib/eth-jit-exiter
+
 ENTRYPOINT [ "/bin/eth-jit-exiter" ]

--- a/README.md
+++ b/README.md
@@ -105,4 +105,3 @@ Make sure to secure the environment where you're running both the webhook and si
 ## License
 
 [Apache License v2](LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ running_mode: SERVER
 # If both are present, the environment variable has precedence.
 port: 13131
 
+# Rate limit on the webhook endpoint.
+# Default is 500 requests per 7 days.
+rate_limit:
+  request_rate: 500
+  interval: 604800
+
 # List of SIGNER endpoints
 signer_endpoints:
   - http://signer-a.example.com:13131
@@ -95,6 +101,14 @@ dirk:
   # Name of the Wallet
   wallet: Wallet
 ```
+
+## Rate Limit
+
+By default, requests to the webhook are rate limited.
+
+In order for the volume counter to be persisted, SQLite is used as a backend.
+
+A persistent volume is necessary when running in Docker, mapped to `/var/lib/eth-jit-exiter/`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ Make sure to secure the environment where you're running both the webhook and si
 ## License
 
 [Apache License v2](LICENSE)
+

--- a/eth_jit_exiter/signer_server.py
+++ b/eth_jit_exiter/signer_server.py
@@ -122,6 +122,11 @@ def get_composite_signature(credentials, account, data, domain):
 
     return BLSSignature.from_obj(recovered_signature)
 
+@app.route('/ping', methods=["GET"])
+def ping():
+    """Send a 200 response so the webhook knows the connection is fine."""
+    return {"message": "Pong!"}
+
 @app.route('/exit-validator', methods=["POST"])
 def exit_validator():
     endpoint = CONFIG['dirk']['endpoint']

--- a/eth_jit_exiter/signer_server.py
+++ b/eth_jit_exiter/signer_server.py
@@ -1,13 +1,14 @@
+import os
 import logging
 import binascii
 import math
-import random
 import collections
 
 import grpc
 import requests
 
 from flask import Flask, request
+from waitress import serve
 from eth2spec.phase0.mainnet import DOMAIN_VOLUNTARY_EXIT, compute_domain, Version, VoluntaryExit, compute_signing_root, Root, Epoch, ValidatorIndex, bls, BLSPubkey, BLSSignature
 
 from eth_jit_exiter import signer_pb2
@@ -33,6 +34,7 @@ def lagrange_coefficient(i, indices, field_modulus):
     return lc
 
 def bls_signature_recover(_signatures):
+    """Lagrange Interpolation"""
     _signatures = collections.OrderedDict(sorted(_signatures.items()))
     indices = [x[0] for x in _signatures.items()]
     signatures = [x[1] for x in _signatures.items()]
@@ -122,27 +124,8 @@ def get_composite_signature(credentials, account, data, domain):
 
     return BLSSignature.from_obj(recovered_signature)
 
-@app.route('/ping', methods=["GET"])
-def ping():
-    """Send a 200 response so the webhook knows the connection is fine."""
-    return {"message": "Pong!"}
-
-@app.route('/exit-validator', methods=["POST"])
-def exit_validator():
-    endpoint = CONFIG['dirk']['endpoint']
-
-    LOGGER.info(f"Getting accounts list from endpoint {endpoint}")
-
-    request_data = request.json
-
-    LOGGER.info(request_data)
-
-    public_key = request_data.get('validator_pub_key')
-    validator_index = int(request_data.get('validator_index'))
-
-    if public_key.startswith('0x'):
-        public_key = public_key[2:]
-
+def get_grpc_credentials():
+    """Generate the gRPC SSL channel credentials"""
     root_certs = open(CONFIG['dirk']['ca_cert'], 'rb').read()
     client_key = open(CONFIG['dirk']['client_key'], 'rb').read()
     client_cert = open(CONFIG['dirk']['client_cert'], 'rb').read()
@@ -153,8 +136,19 @@ def exit_validator():
         certificate_chain=client_cert,
     )
 
+    return credentials
+
+def get_wallet_accounts():
+    """Return a list of all the accounts in the wallet."""
+    endpoint = CONFIG['dirk']['endpoint']
+
+    LOGGER.info(f"Getting accounts list from endpoint {endpoint}")
+
+    credentials = get_grpc_credentials()
+
     channel = grpc.secure_channel(endpoint, credentials)
     LOGGER.info("Waiting for List Accounts channel...")
+
     grpc.channel_ready_future(channel).result()
     LOGGER.info("Channel connected!")
 
@@ -166,33 +160,61 @@ def exit_validator():
 
     accounts_by_pub = {binascii.b2a_hex(account.composite_public_key).decode():account for account in accounts.DistributedAccounts}
 
-    if public_key in accounts_by_pub:
-        account = accounts_by_pub[public_key]
+    return accounts_by_pub
+
+def generate_voluntary_exit(account, validator_index):
+    LOGGER.info(f"Generating voluntary exit for {account.name}")
+    beacon_data = get_beacon_data()
+
+    LOGGER.info(beacon_data)
+
+    voluntary_exit = VoluntaryExit(
+        epoch=beacon_data['current_epoch'],
+        validator_index=ValidatorIndex(validator_index),
+    )
+
+    domain = compute_domain(DOMAIN_VOLUNTARY_EXIT, beacon_data['current_fork_version'], beacon_data['genesis_validators_root'])
+
+    LOGGER.info(f"Domain: {domain}")
+
+    credentials = get_grpc_credentials()
+
+    signature = get_composite_signature(
+        credentials=credentials,
+        account=account,
+        data=voluntary_exit.hash_tree_root(),
+        domain=domain
+    )
+
+    return voluntary_exit, signature, domain
+
+@app.route('/ping', methods=["GET"])
+def ping():
+    """Send a 200 response so the webhook knows the connection is fine."""
+    return {"message": "Pong!"}
+
+@app.route('/exit-validator', methods=["POST"])
+def exit_validator():
+    request_data = request.json
+
+    LOGGER.info(request_data)
+
+    public_key = request_data.get('validator_pub_key')
+    validator_index = int(request_data.get('validator_index'))
+
+    if public_key.startswith('0x'):
+        public_key = public_key[2:]
+
+    accounts = get_wallet_accounts()
+
+    if public_key in accounts:
+        account = accounts[public_key]
 
         LOGGER.info(f"Using public key {public_key}")
         LOGGER.info(f"Account name: {account.name}")
 
-        beacon_data = get_beacon_data()
-
-        LOGGER.info(beacon_data)
-
-        voluntary_exit = VoluntaryExit(
-            epoch=beacon_data['current_epoch'],
-            validator_index=ValidatorIndex(validator_index),
-        )
-
-        domain = compute_domain(DOMAIN_VOLUNTARY_EXIT, beacon_data['current_fork_version'], beacon_data['genesis_validators_root'])
-
-        LOGGER.info(f"Domain: {domain}")
-
         try:
-            signature = get_composite_signature(
-                credentials=credentials,
-                account=account,
-                data=voluntary_exit.hash_tree_root(),
-                domain=domain
-            )
-
+            voluntary_exit, signature, domain = generate_voluntary_exit(account, validator_index)
             signing_root = compute_signing_root(voluntary_exit, domain)
             valid = bls.Verify(BLSPubkey.fromhex(public_key), signing_root, signature)
             LOGGER.info(f"Is signature valid? {valid}")
@@ -214,11 +236,31 @@ def exit_validator():
             LOGGER.error(err)
             return {'status': 'ERROR WHEN GENERATING SIGNATURE'}, 400
     else:
-        channel.close()
-        LOGGER.info("Channel closed.")
         return {'status': 'NOT FOUND'}, 404
+
+def check_signing():
+    """Check that we're able to get signatures from Dirk using Validator Index `0` so it's never submittable."""
+    LOGGER.info("Checking that we can get signatures from Dirk.")
+    accounts = get_wallet_accounts()
+    account = accounts[list(accounts.keys())[0]]
+
+    voluntary_exit, signature, domain = generate_voluntary_exit(account, 1)
+
+    signing_root = compute_signing_root(voluntary_exit, domain)
+
+    valid = bls.Verify(BLSPubkey.from_obj(account.composite_public_key), signing_root, signature)
+
+    if valid:
+        LOGGER.info("Test signature is valid!")
+    else:
+        LOGGER.error("Generated signature is not valid!")
 
 def start_server(config):
     global CONFIG
     CONFIG = config
-    app.run('0.0.0.0', config.get('port', 13131))
+    check_signing()
+
+    if os.getenv('FLASK_DEBUG', None) == '1':
+        app.run('0.0.0.0', config.get('port', 13131))
+    else:
+        serve(app, host="0.0.0.0", port=config.get('port', 13131))

--- a/eth_jit_exiter/webhook_server.py
+++ b/eth_jit_exiter/webhook_server.py
@@ -11,25 +11,33 @@ LOGGER = logging.getLogger()
 app = Flask(__name__)
 CONFIG = {}
 
-async def request_exit(session, url, payload):
+async def make_request(session, method, url, payload):
     try:
-        response = await session.request(method='POST', url=url, json=payload)
-        return await response.json()
+        response = await session.request(method=method, url=url, json=payload)
+        body = await response.json()
+
+        return {
+            "status": response.status,
+            "url": url,
+            "body": body
+        }
     except Exception as error:
-        LOGGER.error(error)
+        LOGGER.error(f"Error when sending request to {url}: {error}")
 
     # There was no response, so we generate a fail response.
     LOGGER.error(f"There was no response from the endpoint {url}")
 
     return {
-        "status": "FAILED",
-        "description": f"There was no response from the endpoint {url}"
+        "status": 500,
+        "body": {
+            "message": f"There was no response from the host"
+        },
+        "url": url,
     }
 
-
-async def async_requests(payload):
+async def async_requests(method, path, payload=None):
     async with ClientSession() as session:
-        return await asyncio.gather(*[request_exit(session, f"{endpoint}/exit-validator", payload) for endpoint in CONFIG['signer_endpoints']])
+        return await asyncio.gather(*[make_request(session, method, f"{endpoint}/{path}", payload) for endpoint in CONFIG['signer_endpoints']])
 
 # { "validatorIndex": "123", "validatorPubkey": "0x123" }
 @app.route("/webhook", methods=["POST"])
@@ -45,23 +53,44 @@ def exit_webhook():
     if validator_index and validator_pub_key:
         # Asynchronously request every client to sign and submit the exit message
         # if they find the public key on their dirk instances
-        sign_requests = async_requests({
-            'validator_index': validator_index,
-            'validator_pub_key': validator_pub_key
-        })
+        sign_requests = async_requests(
+            method='POST',
+            path="exit-validator",
+            payload={
+                'validator_index': validator_index,
+                'validator_pub_key': validator_pub_key
+            }
+        )
 
         responses = asyncio.run(sign_requests)
 
         LOGGER.info(responses)
 
         for response in responses:
-            if response.get('status', None) == 'SUCCEEDED':
+            reponse_body = response['body']
+
+            if reponse_body.get('status', None) == 'SUCCEEDED':
                 return {"status": "SUCCEEDED"}, 200
 
     return {"status": "FAILED"}, 418
 
+def check_signer_endpoints():
+    """Check that all SIGNER endpoints can be reached."""
+    responses = asyncio.run(async_requests(
+        method='GET',
+        path='ping'
+    ))
+
+    LOGGER.info("Testing connection to all SIGNER endpoints:")
+
+    for response in responses:
+        LOGGER.info(f"{response['url']} response: {response['body']}")
+
+        if response.get('status', None) != 200:
+            LOGGER.error(f"Error response from {response['url']} when testing endpoints: {response['body']}")
 
 def start_server(config):
     global CONFIG
     CONFIG = config
+    check_signer_endpoints()
     app.run('0.0.0.0', CONFIG.get('port', 13131))

--- a/eth_jit_exiter/webhook_server.py
+++ b/eth_jit_exiter/webhook_server.py
@@ -1,8 +1,10 @@
+import os
 import logging
 import asyncio
 
 from aiohttp import ClientSession
 from flask import Flask, request
+from waitress import serve
 
 logging.basicConfig()
 
@@ -93,4 +95,7 @@ def start_server(config):
     global CONFIG
     CONFIG = config
     check_signer_endpoints()
-    app.run('0.0.0.0', CONFIG.get('port', 13131))
+    if os.getenv('FLASK_DEBUG', None) == '1':
+        app.run('0.0.0.0', config.get('port', 13131))
+    else:
+        serve(app, host="0.0.0.0", port=config.get('port', 13131))

--- a/poetry.lock
+++ b/poetry.lock
@@ -1413,6 +1413,22 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "waitress"
+version = "2.1.2"
+description = "Waitress WSGI server"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "waitress-2.1.2-py3-none-any.whl", hash = "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a"},
+    {file = "waitress-2.1.2.tar.gz", hash = "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
+
+[[package]]
 name = "werkzeug"
 version = "2.2.3"
 description = "The comprehensive WSGI web application library."
@@ -1537,4 +1553,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "444656d67fd70fdee67ff072d6b7ea2d5a0cfc87e2a40130f22902dbae2c9fcf"
+content-hash = "b99080415b0bcfba47a21ec9496db9e8f3b7bb612625f730931809956be396d2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1223,6 +1223,22 @@ files = [
 ]
 
 [[package]]
+name = "pyrate-limiter"
+version = "2.10.0"
+description = "Python Rate-Limiter using Leaky-Bucket Algorithm"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pyrate_limiter-2.10.0-py3-none-any.whl", hash = "sha256:a99e52159f5ed5eb58118bed8c645e30818e7c0e0d127a0585c8277c776b0f7f"},
+    {file = "pyrate_limiter-2.10.0.tar.gz", hash = "sha256:98cc52cdbe058458e945ae87d4fd5a73186497ffa545ee6e98372f8599a5bd34"},
+]
+
+[package.extras]
+all = ["filelock (>=3.0)", "redis (>=3.3,<4.0)", "redis-py-cluster (>=2.1.3,<3.0.0)"]
+docs = ["furo (>=2022.3.4,<2023.0.0)", "myst-parser (>=0.17)", "sphinx (>=4.3.0,<5.0.0)", "sphinx-autodoc-typehints (>=1.17,<2.0)", "sphinx-copybutton (>=0.5)", "sphinxcontrib-apidoc (>=0.3,<0.4)"]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -1553,4 +1569,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "b99080415b0bcfba47a21ec9496db9e8f3b7bb612625f730931809956be396d2"
+content-hash = "1df77e2168367c7bf7e648ca1a035d47b67d749075ba20d12c79fd73830683af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ aiohttp = "^3.8.4"
 pyinstaller = "^5.10.1"
 google-api-core = "^2.11.0"
 waitress = "^2.1.2"
+pyrate-limiter = "^2.10.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ setuptools = "^67.6.1"
 aiohttp = "^3.8.4"
 pyinstaller = "^5.10.1"
 google-api-core = "^2.11.0"
+waitress = "^2.1.2"
 
 
 [build-system]


### PR DESCRIPTION
- WEBHOOK mode: Test connection to SIGNER nodes on start
- SIGNER mode: Test getting the signature for one test Voluntary Exit message on start. It uses Validator Index `0` so it's never submittable.
- Use [Waitress](https://docs.pylonsproject.org/projects/waitress/en/stable/) as WSGI server when running in production. Still uses Werkzeug in dev environments.
- Reduced docker image size
- Added rate limiter to webhook endpoint